### PR TITLE
Preserve VLESS transport options in Sing-Box export

### DIFF
--- a/src/generator/config/subexport.cpp
+++ b/src/generator/config/subexport.cpp
@@ -2620,7 +2620,10 @@ void proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json, std::v
             case ProxyType::VLESS:
             {
                 addSingBoxCommonMembers(proxy, x, "vless", allocator);
-                proxy.AddMember("packet_encoding", "xudp", allocator);
+                if (!x.PacketEncoding.empty())
+                    proxy.AddMember("packet_encoding", rapidjson::StringRef(x.PacketEncoding.c_str()), allocator);
+                else
+                    proxy.AddMember("packet_encoding", "xudp", allocator);
 
                 if (!x.UUID.empty())
                     proxy.AddMember("uuid", rapidjson::StringRef(x.UUID.c_str()), allocator);
@@ -2633,9 +2636,13 @@ void proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json, std::v
                 } else if (!x.Flow.empty()) {
                     proxy.AddMember("flow", rapidjson::StringRef(x.Flow.c_str()), allocator);
                 }
+
+                auto transport = buildSingBoxTransport(x, allocator);
+                if (!transport.ObjectEmpty())
+                    proxy.AddMember("transport", transport, allocator);
                 // TLS 配置
                 rapidjson::Value tls(rapidjson::kObjectType);
-                tls.AddMember("enabled", true, allocator);
+                tls.AddMember("enabled", x.TLSSecure || !x.PublicKey.empty() || !x.ShortID.empty(), allocator);
 
                 if (!scv.is_undef())
                     tls.AddMember("insecure", scv.get(), allocator);
@@ -2658,9 +2665,14 @@ void proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json, std::v
                     tls.AddMember("reality", reality, allocator);
 
                     rapidjson::Value utls(rapidjson::kObjectType);
-                    utls.AddMember("enable",true,allocator);
-                    std::array<std::string, 6> fingerprints = {"chrome", "firefox", "safari", "ios", "edge", "qq"};
-                    utls.AddMember("fingerprint", rapidjson::Value(fingerprints[rand() % fingerprints.size()].c_str(), allocator), allocator);
+                    utls.AddMember("enable", true, allocator);
+                    if (!x.Fingerprint.empty())
+                        utls.AddMember("fingerprint", rapidjson::StringRef(x.Fingerprint.c_str()), allocator);
+                    else
+                    {
+                        std::array<std::string, 6> fingerprints = {"chrome", "firefox", "safari", "ios", "edge", "qq"};
+                        utls.AddMember("fingerprint", rapidjson::Value(fingerprints[rand() % fingerprints.size()].c_str(), allocator), allocator);
+                    }
                     tls.AddMember("utls", utls, allocator);
                 }
 
@@ -2690,14 +2702,17 @@ void proxyToSingBox(std::vector<Proxy> &nodes, rapidjson::Document &json, std::v
         }
         if (x.TLSSecure)
         {
-            rapidjson::Value tls(rapidjson::kObjectType);
-            tls.AddMember("enabled", true, allocator);
-            if (!x.ServerName.empty())
-                tls.AddMember("server_name", rapidjson::StringRef(x.ServerName.c_str()), allocator);
-            else if (!x.Host.empty())
-                tls.AddMember("server_name", rapidjson::StringRef(x.Host.c_str()), allocator);
-            tls.AddMember("insecure", buildBooleanValue(scv), allocator);
-            proxy.AddMember("tls", tls, allocator);
+            if (proxy.FindMember("tls") == proxy.MemberEnd())
+            {
+                rapidjson::Value tls(rapidjson::kObjectType);
+                tls.AddMember("enabled", true, allocator);
+                if (!x.ServerName.empty())
+                    tls.AddMember("server_name", rapidjson::StringRef(x.ServerName.c_str()), allocator);
+                else if (!x.Host.empty())
+                    tls.AddMember("server_name", rapidjson::StringRef(x.Host.c_str()), allocator);
+                tls.AddMember("insecure", buildBooleanValue(scv), allocator);
+                proxy.AddMember("tls", tls, allocator);
+            }
         }
         if (!udp.is_undef() && !udp)
         {

--- a/src/parser/subparser.h
+++ b/src/parser/subparser.h
@@ -140,6 +140,13 @@ void vlessConstruct(
         const std::string &xtls,
         const std::string &public_key,
         const std::string &short_id,
+        const std::string &network,
+        const std::string &host,
+        const std::string &edge,
+        const std::string &path,
+        const std::string &packet_encoding,
+        bool tls_secure,
+        tribool udp,
         tribool tfo,
         tribool scv,
         const std::string &underlying_proxy = ""


### PR DESCRIPTION
## Summary
- capture additional VLESS options such as packet encoding, transport settings, TLS fingerprint, and Reality keys while parsing Clash nodes and VLESS URLs
- extend the VLESS constructor to store UDP state, network metadata, and TLS preferences so they survive later conversions
- include the captured VLESS settings when exporting to Sing-Box, reusing the provided fingerprint for uTLS and avoiding duplicate TLS blocks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d5fb9602d88328915438d5bfbb0cb3